### PR TITLE
Fix canceled typo in ReservationStatus

### DIFF
--- a/concert-ticketing/src/main/java/com/hhplus/concertticketing/application/usecase/ReservationUseCase.java
+++ b/concert-ticketing/src/main/java/com/hhplus/concertticketing/application/usecase/ReservationUseCase.java
@@ -36,7 +36,7 @@ public class ReservationUseCase {
     public void checkAndUpdateExpiredReservations() {
         List<Reservation> expiredReservations = reservationService.getExpiredReservations(LocalDateTime.now());
         for (Reservation reservation : expiredReservations) {
-            reservation.setStatus(ReservationStatus.CANCLED);
+            reservation.setStatus(ReservationStatus.CANCELED);
             reservationService.updateReservationStatus(reservation);
             concertService.unlockSeat(reservation.getSeatId());
             concertService.markConcertOptionAsAvailableIfSeatsExist(reservation.getConcertOptionId());

--- a/concert-ticketing/src/main/java/com/hhplus/concertticketing/domain/model/Reservation.java
+++ b/concert-ticketing/src/main/java/com/hhplus/concertticketing/domain/model/Reservation.java
@@ -22,7 +22,7 @@ public class Reservation {
     private Long concertOptionId;
 
     @Enumerated(EnumType.STRING)
-    private ReservationStatus status; // RESERVING, RESERVED, CANCLED
+    private ReservationStatus status; // RESERVING, PAID, CANCELED
 
     private LocalDateTime createdAt;
 

--- a/concert-ticketing/src/main/java/com/hhplus/concertticketing/domain/model/ReservationStatus.java
+++ b/concert-ticketing/src/main/java/com/hhplus/concertticketing/domain/model/ReservationStatus.java
@@ -3,5 +3,5 @@ package com.hhplus.concertticketing.domain.model;
 public enum ReservationStatus {
     RESERVING,
     PAID,
-    CANCLED
+    CANCELED
 }

--- a/concert-ticketing/src/test/java/com/hhplus/concertticketing/application/usecase/ReservationUseCaseIntegrationTest.java
+++ b/concert-ticketing/src/test/java/com/hhplus/concertticketing/application/usecase/ReservationUseCaseIntegrationTest.java
@@ -110,7 +110,7 @@ public class ReservationUseCaseIntegrationTest {
         reservationUseCase.checkAndUpdateExpiredReservations();
 
         Reservation updatedReservation = reservationRepository.getReservationById(reservation.getId()).orElseThrow();
-        assertEquals(ReservationStatus.CANCLED, updatedReservation.getStatus());
+        assertEquals(ReservationStatus.CANCELED, updatedReservation.getStatus());
 
         Seat updatedSeat = seatRepository.getSeatById(seat.getId()).orElseThrow();
         assertEquals(SeatStatus.AVAILABLE, updatedSeat.getStatus());


### PR DESCRIPTION
## Summary
- fix ReservationStatus enum value name
- correct all references in source and test code

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6847950a58788320aed1917f3cfc6626