### PR TITLE
Fix token validation in reservation flow

### DIFF
--- a/concert-ticketing/src/main/java/com/hhplus/concertticketing/application/usecase/ReservationUseCase.java
+++ b/concert-ticketing/src/main/java/com/hhplus/concertticketing/application/usecase/ReservationUseCase.java
@@ -3,6 +3,7 @@ package com.hhplus.concertticketing.application.usecase;
 import com.hhplus.concertticketing.domain.model.Reservation;
 import com.hhplus.concertticketing.domain.model.ReservationStatus;
 import com.hhplus.concertticketing.domain.model.Token;
+import com.hhplus.concertticketing.domain.model.TokenStatus;
 import com.hhplus.concertticketing.domain.service.ConcertService;
 import com.hhplus.concertticketing.domain.service.ReservationService;
 import com.hhplus.concertticketing.domain.service.TokenService;
@@ -47,6 +48,9 @@ public class ReservationUseCase {
     public ReservationResponse reserveTicket(ReservationRequest reservationRequest) {
         try {
             Token token = tokenService.getTokenByTokenValue(reservationRequest.getTokenValue());
+            if (token == null || !TokenStatus.ACTIVE.equals(token.getStatus())) {
+                throw new CustomException(ErrorCode.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+            }
             concertService.lockSeat(reservationRequest.getConcertOptionId(), reservationRequest.getSeatId());
             Reservation reservation = reservationService.reserveTicket(token.getCustomerId(), reservationRequest.getConcertOptionId(), reservationRequest.getSeatId());
             return new ReservationResponse(reservation.getId(), reservation.getStatus(), reservation.getExpiresAt());

--- a/concert-ticketing/src/test/java/com/hhplus/concertticketing/application/usecase/ReservationUseCaseTokenValidationTest.java
+++ b/concert-ticketing/src/test/java/com/hhplus/concertticketing/application/usecase/ReservationUseCaseTokenValidationTest.java
@@ -1,0 +1,77 @@
+package com.hhplus.concertticketing.application.usecase;
+
+import com.hhplus.concertticketing.domain.model.Token;
+import com.hhplus.concertticketing.domain.model.TokenStatus;
+import com.hhplus.concertticketing.domain.service.ConcertService;
+import com.hhplus.concertticketing.domain.service.ReservationService;
+import com.hhplus.concertticketing.domain.service.TokenService;
+import com.hhplus.concertticketing.Interfaces.presentation.dto.request.ReservationRequest;
+import com.hhplus.concertticketing.common.exception.CustomException;
+import com.hhplus.concertticketing.common.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ReservationUseCaseTokenValidationTest {
+
+    @Mock
+    private ReservationService reservationService;
+
+    @Mock
+    private ConcertService concertService;
+
+    @Mock
+    private TokenService tokenService;
+
+    @InjectMocks
+    private ReservationUseCase reservationUseCase;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("토큰이 존재하지 않으면 UNAUTHORIZED 예외 발생")
+    void reserveTicket_ShouldThrowException_WhenTokenMissing() {
+        ReservationRequest request = new ReservationRequest();
+        request.setTokenValue("invalid");
+        request.setConcertOptionId(1L);
+        request.setSeatId(1L);
+
+        when(tokenService.getTokenByTokenValue("invalid")).thenReturn(null);
+
+        CustomException exception = assertThrows(CustomException.class, () -> reservationUseCase.reserveTicket(request));
+
+        assertEquals(ErrorCode.UNAUTHORIZED, exception.getErrorCode());
+        verify(tokenService).getTokenByTokenValue("invalid");
+        verifyNoInteractions(concertService, reservationService);
+    }
+
+    @Test
+    @DisplayName("토큰 상태가 ACTIVE가 아니면 UNAUTHORIZED 예외 발생")
+    void reserveTicket_ShouldThrowException_WhenTokenNotActive() {
+        ReservationRequest request = new ReservationRequest();
+        request.setTokenValue("token");
+        request.setConcertOptionId(1L);
+        request.setSeatId(1L);
+
+        Token token = new Token();
+        token.setTokenValue("token");
+        token.setStatus(TokenStatus.WAITING);
+
+        when(tokenService.getTokenByTokenValue("token")).thenReturn(token);
+
+        CustomException exception = assertThrows(CustomException.class, () -> reservationUseCase.reserveTicket(request));
+
+        assertEquals(ErrorCode.UNAUTHORIZED, exception.getErrorCode());
+        verify(tokenService).getTokenByTokenValue("token");
+        verifyNoInteractions(concertService, reservationService);
+    }
+}


### PR DESCRIPTION
## Summary
- validate token existence and status in `ReservationUseCase.reserveTicket`
- add unit tests to ensure unauthorized access throws `CustomException`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68479523564483208f563e3cc9a3b4ea